### PR TITLE
Autodeploy to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    if: github.repository == 'hugovk/em-keyboard'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: deploy-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            deploy-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python setup.py sdist --format=gztar bdist_wheel
+          twine check dist/*
+
+      - name: Publish package to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,23 @@
+# Release Checklist
+
+- [ ] Get master to the appropriate code release state.
+      [GitHub Actions](https://github.com/hugovk/em-keyboard/actions) should be running
+      cleanly for all merges to master.
+      [![GitHub Actions status](https://github.com/hugovk/em-keyboard/workflows/Test/badge.svg)](https://github.com/hugovk/em-keyboard/actions)
+
+- [ ] Edit release draft, adjust text if needed:
+      https://github.com/hugovk/em-keyboard/releases
+
+- [ ] Check next tag is correct, amend if needed
+
+- [ ] Publish release
+
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/hugovk/em-keyboard/actions?query=workflow%3ADeploy)
+      has deployed to [PyPI](https://pypi.org/project/em-keyboard/#history)
+
+- [ ] Check installation:
+
+```bash
+pip3 uninstall -y em-keyboard && pip3 install -U em-keyboard && em rocket
+```


### PR DESCRIPTION
Deploy to TestPyPI on merges to master, to PyPI for releases.

Uses https://github.com/pypa/gh-action-pypi-publish.

I created API tokens for TestPyPI and production PyPI, and added them to the repo settings.

https://pypi.org/help/#apitoken