### PR TITLE
Fix autodeploy secret names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,11 +47,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.test_pypi_password }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Re: https://github.com/pypa/gh-action-pypi-publish/commit/4425980a3392e9b685c45af290ba37dc79870af9 / https://github.com/pypa/gh-action-pypi-publish/pull/52:

> Use PYPI_API_TOKEN instead of pypi_password as secret name in examples
>
> GitHub secrets are customarily spelled in uppercase, and in PyPI terms we're dealing with API tokens here, not passwords.

