### PR TITLE
Set encoding when opening files to fix Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov
           - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }
           - { codecov-flag: GHA_macOS, os: macos-latest }
+          - { codecov-flag: GHA_Windows, os: windows-latest }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.10.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -11,7 +11,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.7.0
     hooks:
       - id: isort
 
@@ -22,7 +22,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.0
+    rev: v1.8.0
     hooks:
       - id: python-check-blanket-noqa
 

--- a/em/__init__.py
+++ b/em/__init__.py
@@ -31,8 +31,12 @@ import re
 import sys
 from collections import defaultdict
 
-import xerox
 from docopt import docopt
+
+try:
+    import xerox
+except ImportError:
+    xerox = None
 
 EMOJI_PATH = os.path.join(os.path.dirname(__file__), "emojis.json")
 CUSTOM_EMOJI_PATH = os.path.join(os.path.expanduser("~/.emojis.json"))
@@ -126,7 +130,7 @@ def cli():
     results = "".join(results)
 
     # Copy the results (and say so!) to the clipboard.
-    if not no_copy and not missing:
+    if xerox and not no_copy and not missing:
         xerox.copy(results)
         print(f"Copied! {print_results}")
 

--- a/em/__init__.py
+++ b/em/__init__.py
@@ -39,7 +39,7 @@ CUSTOM_EMOJI_PATH = os.path.join(os.path.expanduser("~/.emojis.json"))
 
 
 def parse_emojis(filename=EMOJI_PATH):
-    return json.load(open(filename))
+    return json.load(open(filename, encoding="utf-8"))
 
 
 def translate(lookup, code):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from codecs import open
 
 from setuptools import setup
 
-with open("README.md") as f:
+with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     zip_safe=False,
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
-    install_requires=["docopt", "xerox; platform_system != 'Windows'"],
+    install_requires=["docopt", "xerox; platform_system == 'Darwin'"],
     extras_require={"tests": ["pytest", "pytest-cov"]},
     python_requires=">=3.6",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     zip_safe=False,
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
-    install_requires=["docopt", "xerox"],
+    install_requires=["docopt", "xerox; platform_system != 'Windows'"],
     extras_require={"tests": ["pytest", "pytest-cov"]},
     python_requires=">=3.6",
     project_urls={

--- a/tests/test_em.py
+++ b/tests/test_em.py
@@ -2,7 +2,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from em import cli
+from em import cli, xerox
 
 
 @pytest.mark.parametrize(
@@ -14,9 +14,8 @@ from em import cli
 )
 @patch("em.docopt")
 @patch("em.sys.exit")
-@patch("em.xerox.copy")
 @patch("builtins.print")
-def test_star(mock_print, mock_xerox, mock_exit, mock_docopt, test_name):
+def test_star(mock_print, mock_exit, mock_docopt, test_name):
     # Arrange
     mock_docopt.return_value = {"<name>": [test_name], "--no-copy": None, "-s": None}
 
@@ -24,15 +23,16 @@ def test_star(mock_print, mock_xerox, mock_exit, mock_docopt, test_name):
     cli()
 
     # Assert
-    mock_xerox.assert_called_once_with("⭐")
-    mock_print.assert_called_once_with("Copied! ⭐")
+    if xerox:
+        mock_print.assert_called_once_with("Copied! ⭐")
+    else:
+        mock_print.assert_called_once_with("⭐")
 
 
 @patch("em.docopt")
 @patch("em.sys.exit")
-@patch("em.xerox.copy")
 @patch("builtins.print")
-def test_not_found(mock_print, mock_xerox, mock_exit, mock_docopt):
+def test_not_found(mock_print, mock_exit, mock_docopt):
     # Arrange
     mock_docopt.return_value = {"<name>": ["xxx"], "--no-copy": None, "-s": None}
 
@@ -40,15 +40,13 @@ def test_not_found(mock_print, mock_xerox, mock_exit, mock_docopt):
     cli()
 
     # Assert
-    mock_xerox.assert_not_called()
     mock_print.assert_called_once_with("")
 
 
 @patch("em.docopt")
 @patch("em.sys.exit")
-@patch("em.xerox.copy")
 @patch("builtins.print")
-def test_no_copy(mock_print, mock_xerox, mock_exit, mock_docopt):
+def test_no_copy(mock_print, mock_exit, mock_docopt):
     # Arrange
     mock_docopt.return_value = {"<name>": ["star"], "--no-copy": True, "-s": None}
 
@@ -56,15 +54,13 @@ def test_no_copy(mock_print, mock_xerox, mock_exit, mock_docopt):
     cli()
 
     # Assert
-    mock_xerox.assert_not_called()
     mock_print.assert_called_once_with("⭐")
 
 
 @patch("em.docopt")
 @patch("em.sys.exit")
-@patch("em.xerox.copy")
 @patch("builtins.print")
-def test_search_star(mock_print, mock_xerox, mock_exit, mock_docopt):
+def test_search_star(mock_print, mock_exit, mock_docopt):
     # Arrange
     mock_docopt.return_value = {"<name>": ["star"], "--no-copy": None, "-s": True}
     expected = (
@@ -77,6 +73,5 @@ def test_search_star(mock_print, mock_xerox, mock_exit, mock_docopt):
     cli()
 
     # Assert
-    mock_xerox.assert_not_called()
     for arg in expected:
         assert call(arg) in mock_print.call_args_list


### PR DESCRIPTION
Fixes #44.

Also:

* remove mandatory xerox requirement on Linux and Windows, it's not trivially installable with pip
* test on Windows
* test on Python 3.10-dev (ahead of release in October)
