### PR TITLE
Add version option

### DIFF
--- a/em/__init__.py
+++ b/em/__init__.py
@@ -23,10 +23,14 @@ import re
 import sys
 from collections import defaultdict
 
+import pkg_resources
+
 try:
     import xerox
 except ImportError:
     xerox = None
+
+__version__: str = pkg_resources.get_distribution("em-keyboard").version
 
 EMOJI_PATH = os.path.join(os.path.dirname(__file__), "emojis.json")
 CUSTOM_EMOJI_PATH = os.path.join(os.path.expanduser("~/.emojis.json"))
@@ -83,6 +87,9 @@ def cli():
     parser.add_argument("-s", "--search", action="store_true", help="Search for emoji")
     parser.add_argument(
         "--no-copy", action="store_true", help="Does not copy emoji to clipboard"
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
     )
     args = parser.parse_args()
     names = tuple(map(clean_name, args.name))


### PR DESCRIPTION
Fixes https://github.com/hugovk/em-keyboard/issues/35.

Use `-V` or `--version` to check the version.

Uppercase `-V` as lowercase `-v` is often used for verbose.

http://www.catb.org/~esr/writings/taoup/html/ch10s05.html

```console
$ em -V
em 1.0.2.dev2
$ em --version
em 1.0.2.dev2
```
```console
$ em --help
usage: em [-h] [-s] [--no-copy] [-V] name [name ...]

em: the technicolor cli emoji keyboard™

Examples:

  $ em sparkle cake sparkles
  $ em heart

  $ em -s food

Notes:
  - If all names provided map to emojis, the resulting emojis will be
    automatically added to your clipboard.
  - ✨ 🍰 ✨  (sparkles cake sparkles)

positional arguments:
  name           Text to convert to emoji

optional arguments:
  -h, --help     show this help message and exit
  -s, --search   Search for emoji
  --no-copy      Does not copy emoji to clipboard
  -V, --version  show program's version number and exit

```