### PR TITLE
Install pyperclip for macOS, prioritise over xerox

### DIFF
--- a/em/__init__.py
+++ b/em/__init__.py
@@ -24,10 +24,10 @@ import sys
 import pkg_resources
 
 try:
-    import xerox as copier
+    import pyperclip as copier
 except ImportError:
     try:
-        import pyperclip as copier
+        import xerox as copier
     except ImportError:
         copier = None
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "xerox; platform_system == 'Darwin'",
+        "pyperclip; platform_system == 'Darwin'",
         "pyperclip; platform_system == 'Windows'",
     ],
     extras_require={"tests": ["pytest", "pytest-cov"]},


### PR DESCRIPTION
Fixes #59.

pyperclip is better maintained: repo updated 7 days ago, last release Feb 21, 2021
* https://github.com/asweigart/
* https://pypi.org/project/pyperclip/

xerox: repo updated on 23 Feb 2018, last release Feb 4, 2016
* https://github.com/adityarathod/xerox
* https://pypi.org/project/xerox/

pyperclip is used for Windows copying as it's a single pip install compared to xerox.

Prioritise pyperclip over xerox.

Keep xerox as a possible copier, as we're not installing either for Linux (sub-dependencies are a bit trickier there) so allow Linux folk to whichever they may have installed.