### PR TITLE
Fix deploy: no need to generate emojis.json during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,6 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U setuptools twine wheel
 
-      - name: Generate emojis.json
-        run: |
-          python scripts/despacify.py
-
       - name: Build package
         run: |
           python setup.py --version


### PR DESCRIPTION
Follow on from https://github.com/hugovk/em-keyboard/pull/62.

`emojis.json` is generated before deploy and is committed in Git.

Fixes:

```
Run python scripts/despacify.py
Traceback (most recent call last):
  File "/home/runner/work/em-keyboard/em-keyboard/scripts/despacify.py", line 7, in <module>
    from em import EMOJI_PATH, parse_emojis
ModuleNotFoundError: No module named 'em'
Error: Process completed with exit code 1.
```