### PR TITLE
Test CLI is runnable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
         run: |
           tox -e py
 
+      - name: Test CLI
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          tox -e cli
+
       - name: Test emojis.json is up-to-date
         run: |
           # Install

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    cli
     lint
     py{310, 39, 38, 37, 36}
 
@@ -9,6 +10,12 @@ extras =
 commands =
     {envpython} -m pytest --cov em --cov tests --cov-report term {posargs}
     {envpython} -m coverage xml
+
+[testenv:cli]
+commands =
+    em --help
+    em --version
+    em -s test
 
 [testenv:lint]
 passenv =


### PR DESCRIPTION
Add a test of running the CLI to prevent https://github.com/hugovk/em-keyboard/pull/65.

Failing build before that revert: 

```
cli run-test: commands[0] | em --help
Traceback (most recent call last):
  File "/home/runner/work/em-keyboard/em-keyboard/.tox/cli/bin/em", line 5, in <module>
    from em import cli
ModuleNotFoundError: No module named 'em'
ERROR: InvocationError for command /home/runner/work/em-keyboard/em-keyboard/.tox/cli/bin/em --help (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   cli: commands failed
Error: Process completed with exit code 1.
```

https://github.com/hugovk/em-keyboard/runs/3775745133?check_suite_focus=true

Passing build after:

```
cli run-test: commands[0] | em --help
usage: em [-h] [-s] [--no-copy] [-V] name [name ...]

em: the technicolor cli emoji keyboard™

Examples:

  $ em sparkle shortcake sparkles
  $ em red_heart

  $ em -s food

Notes:
  - If all names provided map to emojis, the resulting emojis will be
    automatically added to your clipboard.
  - ✨ 🍰 ✨  (sparkles shortcake sparkles)

positional arguments:
  name           Text to convert to emoji

optional arguments:
  -h, --help     show this help message and exit
  -s, --search   Search for emoji
  --no-copy      Does not copy emoji to clipboard
  -V, --version  show program's version number and exit
cli run-test: commands[1] | em --version
em 0.1.dev1
cli run-test: commands[2] | em -s test
💯  hundred_points
⌛  hourglass_done
🏆  trophy
📝  memo
🧪  test_tube
🏁  chequered_flag
___________________________________ summary ____________________________________
  cli: commands succeeded
  congratulations :)
```

https://github.com/hugovk/em-keyboard/runs/3775753672?check_suite_focus=true
