### PR TITLE
Setup: Use declarative metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,12 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.17.0
+    hooks:
+      - id: setup-cfg-fmt
+        args: ["--max-py-version=3.10"]
+
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 0.5.1
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ tests =
     pytest-cov
 
 [options.package_data]
- =
+* =
     LICENSE
     NOTICE
 em =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,14 @@
 [metadata]
-name = em-keyboard
+name = em_keyboard
 description = The CLI Emoji Keyboard
 long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/hugovk/em-keyboard
 author = Kenneth Reitz
 author_email = me@kennethreitz.org
 maintainer = Hugo van Kemenade
-url = https://github.com/hugovk/em-keyboard
 license = ISC
-keywords =
-    CLI
-    emoji
-    keyboard
-    search
-project_urls =
-    Source=https://github.com/hugovk/em-keyboard
+license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
@@ -22,23 +16,31 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
+keywords =
+    CLI
+    emoji
+    keyboard
+    search
+project_urls =
+    Source=https://github.com/hugovk/em-keyboard
 
 [options]
 packages = em
-include_package_data = True
-zip_safe = False
-setup_requires = setuptools_scm
 install_requires =
-    pyperclip; platform_system == 'Darwin'
-    pyperclip; platform_system == 'Windows'
+    pyperclip;platform_system == 'Darwin'
+    pyperclip;platform_system == 'Windows'
 python_requires = >=3.6
+include_package_data = True
+setup_requires =
+    setuptools_scm
+zip_safe = False
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,13 +51,6 @@ tests =
     pytest
     pytest-cov
 
-[options.package_data]
-* =
-    LICENSE
-    NOTICE
-em =
-    emojis.json
-
 [flake8]
 max_line_length = 88
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,61 @@
+[metadata]
+name = em-keyboard
+description = The CLI Emoji Keyboard
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Kenneth Reitz
+author_email = me@kennethreitz.org
+maintainer = Hugo van Kemenade
+url = https://github.com/hugovk/em-keyboard
+license = ISC
+keywords =
+    CLI
+    emoji
+    keyboard
+    search
+project_urls =
+    Source=https://github.com/hugovk/em-keyboard
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: ISC License (ISCL)
+    Natural Language :: English
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
+
+[options]
+packages = em
+include_package_data = True
+zip_safe = False
+setup_requires = setuptools_scm
+install_requires =
+    pyperclip; platform_system == 'Darwin'
+    pyperclip; platform_system == 'Windows'
+python_requires = >=3.6
+
+[options.entry_points]
+console_scripts =
+    em=em:cli
+
+[options.extras_require]
+tests =
+    pytest
+    pytest-cov
+
+[options.package_data]
+ =
+    LICENSE
+    NOTICE
+em =
+    emojis.json
+
 [flake8]
 max_line_length = 88
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import setup
 
-with open("README.md", encoding="utf-8") as f:
-    long_description = f.read()
-
 
 def local_scheme(version):
     """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
@@ -11,50 +8,5 @@ def local_scheme(version):
 
 
 setup(
-    name="em-keyboard",
-    description="The CLI Emoji Keyboard",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Kenneth Reitz",
-    author_email="me@kennethreitz.org",
-    maintainer="Hugo van Kemenade",
-    url="https://github.com/hugovk/em-keyboard",
-    license="ISC",
-    keywords=[
-        "CLI",
-        "emoji",
-        "keyboard",
-        "search",
-    ],
-    packages=["em"],
-    package_data={"": ["LICENSE", "NOTICE"], "em": ["emojis.json"]},
-    include_package_data=True,
-    entry_points={"console_scripts": ["em=em:cli"]},
-    zip_safe=False,
     use_scm_version={"local_scheme": local_scheme},
-    setup_requires=["setuptools_scm"],
-    install_requires=[
-        "pyperclip; platform_system == 'Darwin'",
-        "pyperclip; platform_system == 'Windows'",
-    ],
-    extras_require={"tests": ["pytest", "pytest-cov"]},
-    python_requires=">=3.6",
-    project_urls={
-        "Source": "https://github.com/hugovk/em-keyboard",
-    },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: ISC License (ISCL)",
-        "Natural Language :: English",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: Implementation :: CPython",
-    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "Source": "https://github.com/hugovk/em-keyboard",
     },
     classifiers=[
-        # 'Development Status :: 5 - Production/Stable',
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: ISC License (ISCL)",
         "Natural Language :: English",


### PR DESCRIPTION
Fixed version of https://github.com/hugovk/em-keyboard/pull/64, identical except we need to keep:
```cfg
[options]
packages = em
```