### PR TITLE
Use Codecov GitHub Action v2 instead of deprecated v1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           git diff --name-only --exit-code
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: ${{ matrix.codecov-flag }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos