### PR TITLE
Exit 1 when no search results

### DIFF
--- a/em/__init__.py
+++ b/em/__init__.py
@@ -117,7 +117,10 @@ def cli():
             except TypeError:
                 pass
 
-        sys.exit(0)
+        if len(found):
+            sys.exit(0)
+        else:
+            sys.exit(1)
 
     # Process the results.
     results = (translate(lookup, name) for name in names)

--- a/tests/test_em.py
+++ b/tests/test_em.py
@@ -32,6 +32,7 @@ def test_star(mock_print, mock_exit, mock_argparse, test_name):
         mock_print.assert_called_once_with("Copied! ⭐")
     else:
         mock_print.assert_called_once_with("⭐")
+    mock_exit.assert_called_with(0)
 
 
 @patch("em.argparse.ArgumentParser.parse_args")
@@ -48,6 +49,7 @@ def test_not_found(mock_print, mock_exit, mock_argparse):
 
     # Assert
     mock_print.assert_called_once_with("")
+    mock_exit.assert_called_with(1)
 
 
 @patch("em.argparse.ArgumentParser.parse_args")
@@ -64,6 +66,7 @@ def test_no_copy(mock_print, mock_exit, mock_argparse):
 
     # Assert
     mock_print.assert_called_once_with("⭐")
+    mock_exit.assert_called_with(0)
 
 
 @patch("em.argparse.ArgumentParser.parse_args")
@@ -86,3 +89,21 @@ def test_search_star(mock_print, mock_exit, mock_argparse):
     # Assert
     for arg in expected:
         assert call(arg) in mock_print.call_args_list
+    mock_exit.assert_called_with(0)
+
+
+@patch("em.argparse.ArgumentParser.parse_args")
+@patch("em.sys.exit")
+@patch("builtins.print")
+def test_search_not_found(mock_print, mock_exit, mock_argparse):
+    # Arrange
+    mock_argparse.return_value = argparse.Namespace(
+        name=["twenty_o_clock"], no_copy=None, search=True
+    )
+
+    # Act
+    cli()
+
+    # Assert
+    mock_print.assert_called_once_with("")
+    mock_exit.assert_called_with(1)


### PR DESCRIPTION
Right now, looking for an emoji _without_ `--search` exits 0 on success and 1 for not found:

```console
$ em one_o_clock      # exit code 0
Copied! 🕐
$ em million_o_clock  # exit code 1

$
```

But _with_ `--search` it's always exits with 0:

```console
$ em --search clock         # exit code 0
⌛  hourglass_done
⏰  alarm_clock
⏲️  timer_clock
🕰️  mantelpiece_clock
🕛  twelve_o_clock
🕐  one_o_clock
🕑  two_o_clock
🕒  three_o_clock
🕓  four_o_clock
🕔  five_o_clock
🕕  six_o_clock
🕖  seven_o_clock
🕗  eight_o_clock
🕘  nine_o_clock
🕙  ten_o_clock
🕚  eleven_o_clock
🔃  clockwise_vertical_arrows
🔄  counterclockwise_arrows_button
$ em --search clock2        # exit code 0
$
```

Instead, let's also exit with 1 when none are found:

```console
$ em --search clock2        # exit code 1
$
```
