### PR TITLE
Speedup: replace slow pkg_resources with importlib_metadata

### DIFF
--- a/em/__init__.py
+++ b/em/__init__.py
@@ -21,7 +21,12 @@ import os
 import re
 import sys
 
-import pkg_resources
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Python 3.7 and lower
+    import importlib_metadata
 
 try:
     import pyperclip as copier
@@ -31,7 +36,7 @@ except ImportError:
     except ImportError:
         copier = None
 
-__version__: str = pkg_resources.get_distribution("em-keyboard").version
+__version__: str = importlib_metadata.version("em_keyboard")
 
 EMOJI_PATH = os.path.join(os.path.dirname(__file__), "emojis.json")
 CUSTOM_EMOJI_PATH = os.path.join(os.path.expanduser("~/.emojis.json"))

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ project_urls =
 [options]
 packages = em
 install_requires =
+    importlib-metadata;python_version < '3.8'
     pyperclip;platform_system == 'Darwin'
     pyperclip;platform_system == 'Windows'
 python_requires = >=3.7


### PR DESCRIPTION
Profiled and visualised using https://github.com/nschloe/tuna:

```sh
python -X importtime -c 'import em; print(em.__version__)' 2> import.log
tuna import.log
```

Replacing `pkg_resources` with `importlib_metadata` shaves off about half a second, very noticeable at the command line.

# Before

![image](https://user-images.githubusercontent.com/1324225/147956903-dbce6bab-ccc3-401a-ae36-9ab932e35b51.png)

# After

![image](https://user-images.githubusercontent.com/1324225/147956929-8bc875ea-a482-4c8b-ae51-34338118c0b5.png)



