### PR TITLE
Add PR write permission for github-action-required-labels

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -10,6 +10,7 @@ jobs:
 
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - uses: mheap/github-action-required-labels@v5


### PR DESCRIPTION
The examples at https://github.com/mheap/github-action-required-labels have write permission for both issues and PRs.

This should hopefully avoid the "Approve and run" button that has started showing up for PRs after adding the changelog label. 