### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ htmlcov/
 nosetests.xml
 
 .python-version
+
+# hatch-vcs
+src/*/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ scripts.em = "em_keyboard:cli"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/em_keyboard/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/em_keyboard/__init__.py
+++ b/src/em_keyboard/__init__.py
@@ -16,7 +16,6 @@ Notes:
 from __future__ import annotations
 
 import argparse
-import importlib.metadata
 import itertools
 import json
 import os
@@ -32,7 +31,9 @@ except ImportError:
     except ImportError:
         copier = None
 
-__version__: str = importlib.metadata.version("em_keyboard")
+from em_keyboard import _version
+
+__version__ = _version.__version__
 
 try:
     from importlib.resources import as_file, files


### PR DESCRIPTION
Like https://github.com/hugovk/tinytext/pull/195.

With Python 3.13.0rc1:

```sh
python -X importtime -c "import em_keyboard" 2> import.log && tuna import.log
```

Cuts 7 ms by removing the `importlib.metadata` import.

# `main`

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/9f5ece29-f1a1-4a18-9132-6b6a0c880944">


# PR


<img width="1582" alt="image" src="https://github.com/user-attachments/assets/ea1121ae-c982-4102-a74c-1d6025a405e8">


# hyperfine

```console
❯ hyperfine --warmup 32 \
--prepare "git checkout rm-importlib.metadata" 'python3 -c "import em_keyboard"' \
--prepare "git checkout main"                  'python3 -c "import    em_keyboard"'
Benchmark 1: python3 -c "import em_keyboard"
  Time (mean ± σ):      37.4 ms ±   1.0 ms    [User: 30.2 ms, System: 6.3 ms]
  Range (min … max):    36.1 ms …  42.8 ms    64 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Benchmark 2: python3 -c "import    em_keyboard"
  Time (mean ± σ):      47.2 ms ±   8.4 ms    [User: 37.7 ms, System: 7.7 ms]
  Range (min … max):    44.8 ms … 105.0 ms    52 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Summary
  python3 -c "import em_keyboard" ran
    1.26 ± 0.23 times faster than python3 -c "import    em_keyboard"
```

