### PR TITLE
Use uv to speedup tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
+
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
-          python -m pip install -U tox
+          uv pip install --system -U tox-uv
 
       - name: Tox tests
         run: |
@@ -45,7 +46,7 @@ jobs:
       - name: Test emojis.json is up-to-date
         run: |
           # Install
-          python -m pip install -e .
+          uv pip install --system -e .
           # Regenerate
           python scripts/despacify.py
           # Fail if different


### PR DESCRIPTION
Reduces human waiting time from 2m 57s (total machine time 13m 18s) to 1m 38s (9m 17s).


<img width="925" alt="image" src="https://github.com/user-attachments/assets/15763559-de08-4aef-9885-60d5003cd587">

https://github.com/hugovk/em-keyboard/actions/runs/10647681519/usage

->

<img width="920" alt="image" src="https://github.com/user-attachments/assets/303a1c77-6ebf-4349-baf9-b4871caa435c">

https://github.com/hugovk/em-keyboard/actions/runs/10647730921/usage
