### PR TITLE
Re-add pyperclip dependency on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
+  "pyperclip; platform_system=='Darwin'",
   "pyperclip; platform_system=='Windows'",
 ]
 optional-dependencies.tests = [


### PR DESCRIPTION
For https://github.com/hugovk/em-keyboard/issues/153.

The dependency was removed in https://github.com/hugovk/em-keyboard/pull/141 by a bug in pyproject-fmt. This has since been fixed: https://github.com/tox-dev/pyproject-fmt/issues/231, https://github.com/tox-dev/pyproject-fmt-rust/pull/37.

Let's re-add it.
