### PR TITLE
Remove temporary emoji database copy from wheel and sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ version.source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/em_keyboard/_version.py"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "src/em_keyboard/emoji-en-US.json", # temporary copy of "src/em_keyboard/emojis.json"
+]
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 


### PR DESCRIPTION
It seems that `emoji-en-US.json` is a temporary file, mostly a copy of the final despacified `emojis.json` so perhaps better to leave it out of the wheel and sdist?

This roughly halves the size of wheels built with `pipx run build`.