### PR TITLE
Replace deprecated classifier with licence expression (PEP 639)

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels:
-            "changelog: Added, changelog: Changed, changelog: Deprecated, changelog:
-            Fixed, changelog: Removed, changelog: Security, changelog: skip"
+          labels: |
+            changelog: Added
+            changelog: Changed
+            changelog: Deprecated
+            changelog: Fixed
+            changelog: Removed
+            changelog: Security
+            changelog: skip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.9.3
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
 
@@ -39,7 +39,7 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.2.2
+    rev: v1.3.0
     hooks:
       - id: zizmor
 
@@ -58,12 +58,18 @@ repos:
     hooks:
       - id: tox-ini-fmt
 
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.15.0
+    hooks:
+      - id: yamlfmt
+
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.4.2
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
         exclude: ^src/em/emoji.*\.json$
+        exclude_types: [yaml]
 
   - repo: meta
     hooks:

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,2 @@
+formatter:
+  retain_line_breaks_single: true

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/em-keyboard.svg?logo=python&logoColor=FFE873)](https://pypi.org/project/em-keyboard/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/em-keyboard.svg)](https://pypistats.org/packages/em-keyboard)
 [![GitHub Actions status](https://github.com/hugovk/em-keyboard/workflows/Test/badge.svg)](https://github.com/hugovk/em-keyboard/actions)
-[![codecov](https://codecov.io/gh/hugovk/em-keyboard/branch/main/graph/badge.svg)](https://codecov.io/gh/hugovk/em-keyboard)
-[![GitHub](https://img.shields.io/github/license/hugovk/em-keyboard.svg)](LICENSE)
+[![Codecov](https://codecov.io/gh/hugovk/em-keyboard/branch/main/graph/badge.svg)](https://codecov.io/gh/hugovk/em-keyboard)
+[![Licence](https://img.shields.io/github/license/hugovk/em-keyboard.svg)](LICENSE)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
 **Emoji your friends and colleagues from the comfort of your own terminal.**

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
-# Release Checklist
+# Release checklist
 
 - [ ] Get `main` to the appropriate code release state.
       [GitHub Actions](https://github.com/hugovk/em-keyboard/actions) should be running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ keywords = [
   "keyboard",
   "search",
 ]
-license = { text = "ISC" }
+license = "ISC"
+license-files = [ "LICENSE" ]
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Kenneth Reitz", email = "me@kennethreitz.org" } ]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: ISC License (ISCL)",
   "Natural Language :: English",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
@@ -70,9 +70,9 @@ fix = true
 
 lint.select = [
   "C4",     # flake8-comprehensions
-  "E",      # pycodestyle errors
+  "E",      # pycodestyle
   "EM",     # flake8-errmsg
-  "F",      # pyflakes errors
+  "F",      # pyflakes
   "I",      # isort
   "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
@@ -83,7 +83,7 @@ lint.select = [
   "RUF022", # unsorted-dunder-all
   "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade
-  "W",      # pycodestyle warnings
+  "W",      # pycodestyle
   "YTT",    # flake8-2020
 ]
 lint.ignore = [


### PR DESCRIPTION
* https://peps.python.org/pep-0639/
* https://packaging.python.org/en/latest/specifications/core-metadata/
* https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/170

This depends on (at least) all these, thanks to everyone for making it happen:

* packaging 24.2 https://packaging.pypa.io/en/stable/changelog.html
* Hatchling 1.27 https://hatch.pypa.io/dev/history/hatchling/
* Twine 6.1.0 https://twine.readthedocs.io/en/stable/changelog.html
* PyPI publish GitHub Action v1.12.4 https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4
* build-and-inspect-python-package v2.12.0 https://github.com/hynek/build-and-inspect-python-package/releases/tag/v2.12.0

---

Also update some config.