### PR TITLE
Use `sys.monitoring` for coverage.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,5 +8,7 @@ exclude_also =
     if TYPE_CHECKING:
 
 [run]
+disable_warnings =
+    no-sysmon
 omit =
     **/em/__main__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,10 +105,6 @@ lint.isort.required-imports = [ "from __future__ import annotations" ]
 max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
-filterwarnings = [
-  # Python <= 3.11
-  "ignore:sys.monitoring isn't available, using default core:coverage.exceptions.CoverageWarning",
-]
 testpaths = [ "tests" ]
 
 [tool.mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ env_list =
 [testenv]
 extras =
     tests
+pass_env =
+    FORCE_COLOR
+set_env =
+    COVERAGE_CORE = sysmon
 commands =
     {envpython} -m pytest \
       --cov em \


### PR DESCRIPTION
And exclude warnings for 3.11 and lower via `.coveragerc`.