### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/src/em/cli.py
+++ b/src/em/cli.py
@@ -74,6 +74,7 @@ def parse_args(arg_list: list[str] | None):
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    parser.color = True  # type: ignore[attr-defined]
     parser.add_argument("name", nargs="*", help="Text to convert to emoji")
     parser.add_argument("-s", "--search", action="store_true", help="Search for emoji")
     parser.add_argument("-r", "--random", action="store_true", help="Get random emoji")


### PR DESCRIPTION
Will be available for 3.14 beta:

https://docs.python.org/3.14/library/argparse.html#color


<img width="864" alt="image" src="https://github.com/user-attachments/assets/396ddcac-46e9-4419-b2ce-fc1b5bd68310" />
