### PR TITLE
Remove redundant `try`/`except`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ build.targets.wheel.exclude = [ "src/em/LICENSE" ]
 
 [tool.ruff]
 fix = true
-lint.select = [
+lint.extend-select = [
   "C4",     # flake8-comprehensions
   "E",      # pycodestyle errors
   "EM",     # flake8-errmsg
@@ -69,6 +69,7 @@ lint.select = [
   "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
+  "PERF",   # perflint
   "PGH",    # pygrep-hooks
   "PIE",    # flake8-pie
   "PT",     # flake8-pytest-style

--- a/src/em/cli.py
+++ b/src/em/cli.py
@@ -126,18 +126,12 @@ def main(arg_list: list[str] | None = None) -> str | int:
 
         # print them to the screen.
         for name, emoji in found:
-            # Some registered emoji have no value.
-            try:
-                # Copy the results (and say so!) to the clipboard.
-                if not no_copy and len(found) == 1:
-                    copied = try_copy_to_clipboard(emoji)
-                else:
-                    copied = False
-                print(f"Copied! {emoji}  {name}" if copied else f"{emoji}  {name}")
-
-            # Sometimes, an emoji will have no value.
-            except TypeError:
-                pass
+            # Copy the results (and say so!) to the clipboard.
+            if not no_copy and len(found) == 1:
+                copied = try_copy_to_clipboard(emoji)
+            else:
+                copied = False
+            print(f"Copied! {emoji}  {name}" if copied else f"{emoji}  {name}")
 
         if len(found):
             return 0


### PR DESCRIPTION
Fixes PERF203: `try`-`except` within a loop incurs performance overhead.

A `TypeError` could never be raised in this block.